### PR TITLE
Update supported Python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py33,py34,py35,pypy
+envlist=py27,py34,py35,py36,py37,pypy,pypy3
 
 [testenv]
 commands=py.test -vv


### PR DESCRIPTION
Drops 2.6 and 3.3, adds 3.6, 3.7 and pypy3. 

Python 2 support is tentatively retained only because it isn't a complete pain to deal with