### PR TITLE
Deprecate {choices} in error message

### DIFF
--- a/marshmallow_enum/__init__.py
+++ b/marshmallow_enum/__init__.py
@@ -32,9 +32,10 @@ class EnumField(Field):
         self.enum = enum
         self.by_value = by_value
 
-        if error and any(old in error for old in ('{name', '{value')):
+        if error and any(old in error for old in ('{name', '{value', '{choices')):
             warnings.warn(
-                "'name' and 'value' fail inputs are deprecated, use {input} instead",
+                "'name', 'value', and 'choices' fail inputs are deprecated,"
+                "use input, names and values instead",
                 DeprecationWarning,
                 stacklevel=2
             )
@@ -96,11 +97,14 @@ class EnumField(Field):
             self.fail('by_name', input=value, name=value)
 
     def fail(self, key, **kwargs):
+        kwargs['values'] = ', '.join([str(mem.value) for mem in self.enum])
+        kwargs['names'] = ', '.join([mem.name for mem in self.enum])
+
         if self.error:
             if self.by_value:
-                kwargs['choices'] = ', '.join([str(mem.value) for mem in self.enum])
+                kwargs['choices'] = kwargs['values']
             else:
-                kwargs['choices'] = ', '.join([mem.name for mem in self.enum])
+                kwargs['choices'] = kwargs['names']
             msg = self.error.format(**kwargs)
             raise ValidationError(msg)
         else:

--- a/tests/test_enum_field.py
+++ b/tests/test_enum_field.py
@@ -258,7 +258,7 @@ class TestLoadDumpConfigBehavior(object):
         assert actual == expected
 
 
-@pytest.mark.parametrize('format', ['{name}', '{value}'])
+@pytest.mark.parametrize('format', ['{name}', '{value}', '{choices}'])
 def test_old_error_format_inputs_are_deprecated(format):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always', DeprecationWarning)
@@ -267,4 +267,6 @@ def test_old_error_format_inputs_are_deprecated(format):
 
     assert len(w) == 1
     assert issubclass(w[0].category, DeprecationWarning)
-    assert "use {input}" in str(w[0].message)
+    assert "input" in str(w[0].message)
+    assert "values" in str(w[0].message)
+    assert "names" in str(w[0].message)


### PR DESCRIPTION
Decided to deprecate {choices} as well with the addition of load_by and dump_by, since it'll be impossible to tell what it should be without introspecting the original fail key as well, and the new behavior is more explicit.

This key, as well as {name} and {value}, will be removed in 1.6