### PR TITLE
Add metadata for apispec compatibility

### DIFF
--- a/marshmallow_enum/__init__.py
+++ b/marshmallow_enum/__init__.py
@@ -71,6 +71,11 @@ class EnumField(Field):
 
         super(EnumField, self).__init__(*args, **kwargs)
 
+        self.metadata['enum'] = [
+            e.value if self.by_value else e.name
+            for e in self.enum
+        ]
+
     def _serialize(self, value, attr, obj):
         if value is None:
             return None

--- a/tests/test_enum_field.py
+++ b/tests/test_enum_field.py
@@ -44,6 +44,12 @@ class TestEnumFieldByName(object):
         with pytest.raises(ValidationError):
             self.field._deserialize('fred', None, {})
 
+    def test_enum_metadata(self):
+        assert 'enum' in self.field.metadata
+        assert 'one' in self.field.metadata['enum']
+        assert 'two' in self.field.metadata['enum']
+        assert 'three' in self.field.metadata['enum']
+
 
 class TestEnumFieldValue(object):
 
@@ -65,6 +71,13 @@ class TestEnumFieldValue(object):
 
         with pytest.raises(ValidationError):
             field._deserialize(4, None, {})
+
+    def test_enum_metadata(self):
+        field = EnumField(EnumTester, by_value=True)
+        assert 'enum' in field.metadata
+        assert 1 in field.metadata['enum']
+        assert 2 in field.metadata['enum']
+        assert 3 in field.metadata['enum']
 
 
 class TestEnumFieldAsSchemaMember(object):


### PR DESCRIPTION
fixes #24 

This PR adds the key `enum` to the field's metadata which allows [apispec](https://github.com/marshmallow-code/apispec) (and possibly other tools) to extract the valid enum values.
