### PR TITLE
APISpec quickfix

### DIFF
--- a/marshmallow_enum/__init__.py
+++ b/marshmallow_enum/__init__.py
@@ -33,9 +33,9 @@ class EnumField(Field):
     }
 
     def __init__(
-            self, enum, by_value=False, load_by=None, dump_by=None, error='', *args, **kwargs
+            self, enum_type, by_value=False, load_by=None, dump_by=None, error='', *args, **kwargs
     ):
-        self.enum = enum
+        self.enum = enum_type
         self.by_value = by_value
 
         if error and any(old in error for old in ('{name', '{value', '{choices')):


### PR DESCRIPTION
Problem: Marshmallow_enum.EnumField does not pass the enum as metadata to marshmallow. When used in conjunction with apispec (specifically, the apispec marshmallow extension), this results in EnumFields being converted to a property of just a string type with no additional metadata such as the permitted values of the enum.

Long-term fix: https://github.com/justanr/marshmallow_enum/pull/25

Short term fix: Marshmallow and apispec both permit a workaround of manually specifying an enum value. In marshmallow any Field type can have an extra kwarg called `enum` that will be passed to apispec and correctly appended to the resulting docs. This cannot be done with EnumField because it's first positional argument is already called `enum`. While the pros and cons of potential long-term fixes are debated, this would allow a user to manually specify a value to be passed as `metadata.enum` to marshmallow and apispec. 