### PR TITLE
Fix for marshmallow 3.0.0rc7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ Session.vim
 .netrwhist
 *~
 
+.pytest_cache
+.vscode
+.python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
   - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
 install:
     - pip install tox-travis
 script:

--- a/marshmallow_enum/__init__.py
+++ b/marshmallow_enum/__init__.py
@@ -38,7 +38,7 @@ class EnumField(Field):
         self.enum = enum
         self.by_value = by_value
 
-        if error and any(old in error for old in ('{name', '{value', '{choices')):
+        if error and any(old in error for old in ('name}', 'value}', 'choices}')):
             warnings.warn(
                 "'name', 'value', and 'choices' fail inputs are deprecated,"
                 "use input, names and values instead",
@@ -51,7 +51,7 @@ class EnumField(Field):
         if load_by is None:
             load_by = LoadDumpOptions.value if by_value else LoadDumpOptions.name
 
-        if load_by not in LoadDumpOptions:
+        if not isinstance(load_by, Enum) or load_by not in LoadDumpOptions:
             raise ValueError(
                 'Invalid selection for load_by must be EnumField.VALUE or EnumField.NAME, got {}'.
                 format(load_by)
@@ -60,7 +60,7 @@ class EnumField(Field):
         if dump_by is None:
             dump_by = LoadDumpOptions.value if by_value else LoadDumpOptions.name
 
-        if dump_by not in LoadDumpOptions:
+        if not isinstance(dump_by, Enum) or dump_by not in LoadDumpOptions:
             raise ValueError(
                 'Invalid selection for load_by must be EnumField.VALUE or EnumField.NAME, got {}'.
                 format(dump_by)
@@ -79,7 +79,7 @@ class EnumField(Field):
         else:
             return value.name
 
-    def _deserialize(self, value, attr, data):
+    def _deserialize(self, value, attr, data, **kwargs):
         if value is None:
             return None
         elif self.load_by == LoadDumpOptions.value:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 pytest==3.2.1
 coverage==4.4.1
+flake8==3.6.0
 pytest-flake8==0.9.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,cov-report
+envlist = py27,py34,py35,py36,py37-marshmallow{2, 3},cov-report
 
 [testenv]
 usedevelop = true
@@ -9,6 +9,8 @@ setenv =
 commands =
         coverage run -m pytest
 deps =
+        marshmallow2: marshmallow<3.0.0
+        marshmallow3: marshmallow>=3.0.0rc7
         -r{toxinidir}/requirements-test.txt
 
 [testenv:cov-report]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37-marshmallow{2, 3},cov-report
+envlist = py{27,34}-marshmallow2,py{35,36,37}-marshmallow{2, 3},cov-report
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
- fix needed for marshmallow >= 3.0.0rc7
- fix tests for marshmallow >= 3.0.0
- avoid deprecation warnings
- adds tox environments for python 3.7, marshmallow<3.0.0 and marshmallow>=3.0.0rc7
