### PR TITLE
Deprecated Field.fail replaced with Field.make_error

### DIFF
--- a/marshmallow_enum/__init__.py
+++ b/marshmallow_enum/__init__.py
@@ -114,4 +114,4 @@ class EnumField(Field):
             msg = self.error.format(**kwargs)
             raise ValidationError(msg)
         else:
-            super(EnumField, self).fail(key, **kwargs)
+            raise super(EnumField, self).make_error(key, **kwargs)


### PR DESCRIPTION
Since version 3.0.0 of the marshmallow library the Field.fail is deprecated. Replaced with Field.make_error