### PR TITLE
Fix Field.fail deprecation warning

### DIFF
--- a/marshmallow_enum/__init__.py
+++ b/marshmallow_enum/__init__.py
@@ -4,8 +4,10 @@ import sys
 import warnings
 from enum import Enum
 
+import pkg_resources
 from marshmallow import ValidationError
 from marshmallow.fields import Field
+from packaging import version
 
 PY2 = sys.version_info.major == 2
 # ugh Python 2
@@ -15,6 +17,11 @@ if PY2:
 else:
     string_types = (str, )
     text_type = str
+
+
+MARSHMALLOW2 = (version.parse("2.0.0") <=
+                version.parse(pkg_resources.get_distribution("marshmallow").version) <
+                version.parse("3.0.0"))
 
 
 class LoadDumpOptions(Enum):
@@ -114,4 +121,7 @@ class EnumField(Field):
             msg = self.error.format(**kwargs)
             raise ValidationError(msg)
         else:
-            raise super(EnumField, self).make_error(key, **kwargs)
+            if MARSHMALLOW2:
+                raise super(EnumField, self).fail(key, **kwargs)
+            else:
+                raise super(EnumField, self).make_error(key, **kwargs)

--- a/marshmallow_enum/__init__.py
+++ b/marshmallow_enum/__init__.py
@@ -114,4 +114,4 @@ class EnumField(Field):
             msg = self.error.format(**kwargs)
             raise ValidationError(msg)
         else:
-            super(EnumField, self).fail(key, **kwargs)
+            raise super(EnumField, self).make_error(key, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     extra_requires = ['enum34']
 
-REQUIRES = ['marshmallow>=2.0.0'] + extra_requires
+REQUIRES = ['marshmallow>=2.0.0', 'packaging>=14.0'] + extra_requires
 
 
 with open('README.md', 'r') as f:

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ setenv =
 commands =
         coverage run -m pytest
 deps =
+        packaging>=14.0
         marshmallow2: marshmallow<3.0.0
         marshmallow3: marshmallow>=3.0.0rc7
         -r{toxinidir}/requirements-test.txt


### PR DESCRIPTION
This PR fixes the `Field.fail` deprecation warning that can clog up the logs. See issue #32. 

I'm new around here so apologies if there are developer conventions I've missed. This passes all unit tests and tox tests. 