### PR TITLE
Allow marshmallow_enum to be used for OpenAPI schema definitions

### DIFF
--- a/marshmallow_enum/__init__.py
+++ b/marshmallow_enum/__init__.py
@@ -1,7 +1,9 @@
 from __future__ import unicode_literals
 
+import logging
 import sys
 import warnings
+from enum import Enum
 
 from marshmallow import ValidationError
 from marshmallow.fields import Field
@@ -15,17 +17,62 @@ else:
     string_types = (str, )
     text_type = str
 
+logger = logging.getLogger(__name__)
+
+
+class LoadDumpOptions(Enum):
+    ''' Deprecated: Use the by_value parameter instead '''
+    value = 1
+    name = 0
+
 
 class EnumField(Field):
+    VALUE = LoadDumpOptions.value  # deprecated
+    NAME = LoadDumpOptions.name  # deprecated
+
     default_error_messages = {
         'by_name': 'Invalid enum member {input}',
         'by_value': 'Invalid enum value {input}',
         'must_be_string': 'Enum name must be string'
     }
 
-    def __init__(self, enum_type, by_value=True, error="", *args, **kwargs):
-        self.enum = enum_type
-        self.by_value = by_value
+    def __init__(self, enum_type, by_value=None, load_by=None, dump_by=None,
+                 error="", *args, **kwargs):
+        '''
+        The `load_by` and `dump_by` parameters are deprecated. Use the `by_value` parameter instead.
+
+        '''
+
+        if by_value is None:
+            if load_by is not None:
+                if dump_by is not None and load_by != dump_by:
+                    raise ValueError(
+                        'Deprecated `load_by` parameter must not differ from `dump_by` parameter')
+                by_value = (load_by == LoadDumpOptions.value)
+            elif dump_by is not None:
+                by_value = (dump_by == LoadDumpOptions.value)
+            else:
+                by_value = True
+
+        if load_by is not None:
+            logging.warning(
+                'The `load_by` parameter is deprecated for '
+                'marshmallow_enum.EnumField.__init__(). '
+                'Use the `by_value` parameter instead')
+            load_by_value = (load_by == LoadDumpOptions.value)
+            if load_by_value != by_value:
+                raise ValueError(
+                    'Deprecated load_by_value parameter differs from by_value parameter')
+
+        if dump_by is not None:
+            logging.warning(
+                'The `dump_by` parameter is deprecated for '
+                'marshmallow_enum.EnumField.__init__(). '
+                'Use the `by_value` parameter instead')
+            dump_by_value = (dump_by == LoadDumpOptions.value)
+            if dump_by_value != by_value:
+                raise ValueError(
+                    'Deprecated dump_by_value parameter differs from by_value parameter')
 
         if error and any(old in error for old in ('name}', 'value}', 'choices}')):
             warnings.warn(
@@ -35,6 +82,8 @@ class EnumField(Field):
                 stacklevel=2
             )
 
+        self.enum = enum_type
+        self.by_value = by_value
         self.error = error
 
         super(EnumField, self).__init__(*args, **kwargs)

--- a/marshmallow_enum/__init__.py
+++ b/marshmallow_enum/__init__.py
@@ -100,10 +100,10 @@ class EnumField(Field):
                 self.metadata['type'] = 'boolean'
             elif all(isinstance(v, str) for v in values):
                 self.metadata['type'] = 'string'
-        self.metadata['enum'] = [
+        self.metadata['enum'] = sorted([
             e.value if self.by_value else e.name
             for e in self.enum
-        ]
+        ])
 
     def _serialize(self, value, attr, obj):
         if value is None:

--- a/marshmallow_enum/__init__.py
+++ b/marshmallow_enum/__init__.py
@@ -39,6 +39,18 @@ class EnumField(Field):
 
         super(EnumField, self).__init__(*args, **kwargs)
 
+        if not self.by_value:
+            self.metadata['type'] = 'string'
+        elif self.by_value:
+            values = [e.value for e in self.enum if e.value is not None]
+            if all(isinstance(v, int) for v in values):
+                self.metadata['type'] = 'integer'
+            elif all(isinstance(v, (float, int)) for v in values):
+                self.metadata['type'] = 'number'
+            elif all(isinstance(v, bool) for v in values):
+                self.metadata['type'] = 'boolean'
+            elif all(isinstance(v, str) for v in values):
+                self.metadata['type'] = 'string'
         self.metadata['enum'] = [
             e.value if self.by_value else e.name
             for e in self.enum

--- a/marshmallow_enum/__init__.py
+++ b/marshmallow_enum/__init__.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import sys
 import warnings
-from enum import Enum
 
 from marshmallow import ValidationError
 from marshmallow.fields import Field

--- a/marshmallow_enum/__init__.py
+++ b/marshmallow_enum/__init__.py
@@ -71,6 +71,11 @@ class EnumField(Field):
 
         super(EnumField, self).__init__(*args, **kwargs)
 
+        self.metadata['enum'] = [
+            e.value if self.by_value else e.name
+            for e in self.enum
+        ]
+
     def _serialize(self, value, attr, obj):
         if value is None:
             return None

--- a/tests/test_enum_field.py
+++ b/tests/test_enum_field.py
@@ -44,6 +44,12 @@ class TestEnumFieldByName(object):
         with pytest.raises(ValidationError):
             self.field._deserialize('fred', None, {})
 
+    def test_enum_metadata(self):
+        assert 'enum' in self.field.metadata
+        assert 'one' in self.field.metadata['enum']
+        assert 'two' in self.field.metadata['enum']
+        assert 'three' in self.field.metadata['enum']
+
 
 class TestEnumFieldValue(object):
 
@@ -65,6 +71,13 @@ class TestEnumFieldValue(object):
 
         with pytest.raises(ValidationError):
             field._deserialize(4, None, {})
+
+    def test_enum_metadata(self):
+        field = EnumField(EnumTester, by_value=True)
+        assert 'enum' in field.metadata
+        assert 1 in field.metadata['enum']
+        assert 2 in field.metadata['enum']
+        assert 3 in field.metadata['enum']
 
 
 class TestEnumFieldAsSchemaMember(object):

--- a/tests/test_enum_field.py
+++ b/tests/test_enum_field.py
@@ -51,6 +51,7 @@ class TestEnumFieldByName(object):
         assert 'one' in self.field.metadata['enum']
         assert 'two' in self.field.metadata['enum']
         assert 'three' in self.field.metadata['enum']
+        assert self.field.metadata['type'] == 'string'
 
 
 class TestEnumFieldValue(object):
@@ -80,6 +81,7 @@ class TestEnumFieldValue(object):
         assert 1 in field.metadata['enum']
         assert 2 in field.metadata['enum']
         assert 3 in field.metadata['enum']
+        assert field.metadata['type'] == 'integer'
 
 
 class TestEnumFieldAsSchemaMember(object):


### PR DESCRIPTION
Passing the enum through to the super-class allows it to be used for APISpec/OpenAPI schema definitions, an important use-case for marshmallow. Given that it's the first parameter of the function, the risk that the parameter was referenced by name in a client library is fairly small. Searching through public repositories in GitHub doesn't reveal any clients where this would be problematic.

OpenAPI does not permit the values to differ between loading/dumping. The `load_by` and `dump_by` parameters are still accepted for backward compatibility, but they have been deprecated in favor of the `by_value` parameter.