### PR TITLE
Create a StrictEnumField

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ If either `load_by` or `dump_by` are unset, they will follow from `by_value`.
 Additionally, there is `EnumField.NAME` to be explicit about the load and dump behavior, this
 is the same as leaving both `by_value` and either `load_by` and/or `dump_by` unset.
 
+If you want to ensure that the `load_by` and `dump_by` behaviour is always the same you can use
+the `StrictEnumField`.
+
 ### Custom Error Message
 
 A custom error message can be provided via the `error` keyword argument. It can accept three

--- a/marshmallow_enum/__init__.py
+++ b/marshmallow_enum/__init__.py
@@ -115,3 +115,18 @@ class EnumField(Field):
             raise ValidationError(msg)
         else:
             raise super(EnumField, self).make_error(key, **kwargs)
+
+
+class StrictEnumField(EnumField):
+    """
+    Like EnumField but will always load and dump using the same behaviour
+    Ignores any `load_by` or `dump_by` parameters passed to it
+    """
+
+    def __init__(
+            self, enum, by_value=False, error='', *args, **kwargs
+    ):
+
+        kwargs.pop('load_by', None)
+        kwargs.pop('dump_by', None)
+        super(StrictEnumField, self).__init__(enum, by_value, *args, **kwargs)


### PR DESCRIPTION
One of the issues that is holding up adding ApiSpec support is that EnumField can support different behaviour for `load_by` and `dump_by`. This can be seen in #24, #25, #27, #38 

This PR adds a StrictEnumField which removes that behaviour while retaining backwards compatibility with the current EnumField.

If this PR is approved, then we should be able to add the ApiSpec support to this strict field, and anyone that would like to have ApiSpec support should switch to this one.