### PR TITLE
Make enum types pass validation

### DIFF
--- a/marshmallow_enum/__init__.py
+++ b/marshmallow_enum/__init__.py
@@ -82,6 +82,8 @@ class EnumField(Field):
     def _deserialize(self, value, attr, data, **kwargs):
         if value is None:
             return None
+        elif type(value) == self.enum:
+            return value
         elif self.load_by == LoadDumpOptions.value:
             return self._deserialize_by_value(value, attr, data)
         else:


### PR DESCRIPTION
marshmallow 3.0.0 doesn't perform validation during dump[s]. In order to
get the equivalent behaviour as before, validate must be called. However,
this fails with "Enum name must be string" for the following MWE:

    class MyEnum(Enum):
        a = 1

    class MySchema(Schema):
        my_field = EnumField(MyEnum)

    errors = MySchema().validate({"my_field": MyEnum.a})
    assert not errors

Internally, validate calls _do_load which invokes _deserialize aon all
fields. If there is nothing to deserialize, i.e. the type is already
correct, don't do anything.

Signed-off-by: Sven Schwermer <sven.schwermer@disruptive-technologies.com>