### PR TITLE
Fix usage of deprecated Marshmallow Field.fail

### DIFF
--- a/marshmallow_enum/__init__.py
+++ b/marshmallow_enum/__init__.py
@@ -114,4 +114,4 @@ class EnumField(Field):
             msg = self.error.format(**kwargs)
             raise ValidationError(msg)
         else:
-            super(EnumField, self).fail(key, **kwargs)
+            raise self.make_error(key, **kwargs)


### PR DESCRIPTION
This library still uses Marshmallow's `Field.fail()` to raise errors but [this method is deprecated](https://marshmallow.readthedocs.io/en/stable/marshmallow.fields.html?highlight=Field#marshmallow.fields.Field.fail) and will be removed in Marshmallow 4.

This PR changes marshmallow_enum to use the new method for raising errors.